### PR TITLE
Fix Verifiers::AURORA_MASTER: Pass query options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,7 @@ p curr_thread_id == prev_thread_id #=> false
 In `config/environments/production.rb`:
 
 ```ruby
-ActiveRecordMysqlXverify.verify = ->(conn) do
-  conn.ping && conn.query('select @@innodb_read_only').first.fetch('@@innodb_read_only').zero?
-end
-# Same as below:
-#   ActiveRecordMysqlXverify.verify = ActiveRecordMysqlXverify::Verifiers::AURORA_MASTER
+ActiveRecordMysqlXverify.verify = ActiveRecordMysqlXverify::Verifiers::AURORA_MASTER
 ```
 
 ## Rails log example

--- a/lib/active_record_mysql_xverify/verifiers/aurora_master.rb
+++ b/lib/active_record_mysql_xverify/verifiers/aurora_master.rb
@@ -3,7 +3,15 @@
 module ActiveRecordMysqlXverify
   module Verifiers
     AURORA_MASTER = lambda do |conn|
-      conn.ping && conn.query('select @@innodb_read_only').first.fetch('@@innodb_read_only').zero?
+      conn.ping && conn.query(
+        'select @@innodb_read_only',
+        {
+          as: :hash,
+          async: false,
+          symbolize_keys: false,
+          cast: true,
+        }
+      ).first.fetch('@@innodb_read_only').zero?
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,13 +17,6 @@ RSpec.configure do |config|
   end
 
   config.before :all do
-    conn_spec = {
-      adapter: 'mysql2',
-      host: ENV.fetch('DATABASE_HOST', 'mysql'),
-      username: ENV.fetch('DATABASE_USER', 'root'),
-      database: 'bookshelf',
-    }
-
     ActiveRecord::Base.establish_connection(conn_spec)
 
     @mysql = Mysql2::Client.new(
@@ -43,6 +36,15 @@ end
 module SpecHelper
   def active_record_release_connections
     ActiveRecord::Base.connection_handler.connection_pool_list.each(&:release_connection)
+  end
+
+  def conn_spec
+    {
+      adapter: 'mysql2',
+      host: ENV.fetch('DATABASE_HOST', 'mysql'),
+      username: ENV.fetch('DATABASE_USER', 'root'),
+      database: 'bookshelf',
+    }
   end
 
   def thread_id_changes(model)

--- a/spec/verifiers_aurora_master_spec.rb
+++ b/spec/verifiers_aurora_master_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe 'ActiveRecordMysqlXverify::Verifiers::AURORA_MASTER' do
+  let(:conn) do
+    Mysql2::Client.new(
+      host: conn_spec.fetch(:host),
+      username: conn_spec.fetch(:username),
+      as: :array
+    )
+  end
+
+  specify do
+    is_active = ActiveRecordMysqlXverify::Verifiers::AURORA_MASTER.call(conn)
+    expect(is_active).to be_truthy
+  end
+end


### PR DESCRIPTION
Specify query options to avoid the following errors:

```
TypeError: no implicit conversion of String into Integer
```