### PR TITLE
Adding double splat for Ruby 3.0 support

### DIFF
--- a/lib/active_record_mysql_xverify/error_handler.rb
+++ b/lib/active_record_mysql_xverify/error_handler.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecordMysqlXverify
   module ErrorHandler
-    def execute(*)
+    def execute(*, **)
       super
     rescue StandardError
       _flag_extend_verify!


### PR DESCRIPTION
It seems like splat argument does not pass keyword argument as keyword argument, resulting in us getting ArgumentError:

    ArgumentError: wrong number of arguments (given 3, expected 1..2)
    $GEM_HOME/activerecord-7.0.2.3/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:199:in `execute'
    $GEM_HOME/active_record_mysql_xverify-0.2.2/lib/active_record_mysql_xverify/error_handler.rb:6:in `execute'
    $GEM_HOME/activerecord-7.0.2.3/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:207:in `execute_and_free'
    $GEM_HOME/activerecord-7.0.2.3/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:817:in `column_definitions'
    $GEM_HOME/activerecord-7.0.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:116:in `columns'
    $GEM_HOME/activerecord-7.0.2.3/lib/active_record/connection_adapters/schema_cache.rb:117:in `block in columns'
    $GEM_HOME/activerecord-7.0.2.3/lib/active_record/connection_adapters/schema_cache.rb:116:in `fetch'

If you look at our [caller](https://github.com/rails/rails/blob/v7.0.2.3/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L207), you can see that we're being called with two arguments and one keyword argument:

```ruby
        yield execute(sql, name, async: async)
```

I believe that with a single `*`, this causes us to try to call the [underlying `execute` method](https://github.com/rails/rails/blob/v7.0.2.3/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L199) with `sql, name, { async: async }` as arguments.

Changing this to `*, **` will prevent `async` keyword argument from turning into a Hash.

Note that once we drop Ruby 2.7 support we'll be able to change this method to just accept `...` argument.